### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,8 @@ on:
 jobs:
 
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/korawica/clishelf/security/code-scanning/1](https://github.com/korawica/clishelf/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job to explicitly define the least privileges required. Since the `build` job primarily involves setting up Python, caching dependencies, and running tests, it only needs `contents: read` permissions. This change ensures that the job cannot perform unintended write operations on the repository.

The `permissions` block will be added directly under the `build` job definition on line 17.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
