### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -138,6 +138,8 @@ jobs:
       - build
       - coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
Potential fix for [https://github.com/korawica/clishelf/security/code-scanning/2](https://github.com/korawica/clishelf/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `check` job. Since the job only validates the results of other jobs and does not perform any operations requiring write access, we can set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
